### PR TITLE
fix retry interface with tried count

### DIFF
--- a/retryer.go
+++ b/retryer.go
@@ -18,7 +18,7 @@ func newRetryer[T any](policy RetryPolicy, report *RetryReport, toRetry func() (
 func (r retryer[T]) Run() (T, error) {
 	t, err := r.function()
 	for err != nil {
-		if shouldRetry, duration := r.retryPolicy.ShouldRetry(err); shouldRetry {
+		if shouldRetry, duration := r.retryPolicy.ShouldRetry(err, r.retryReport.Count); shouldRetry {
 			r.retryReport.Count++
 			time.Sleep(duration)
 			t, err = r.function()

--- a/step_exec_data.go
+++ b/step_exec_data.go
@@ -13,5 +13,5 @@ type StepExecutionData struct {
 
 // RetryReport would record the retry count (could extend to include each retry duration, ...)
 type RetryReport struct {
-	Count int
+	Count uint
 }

--- a/step_exec_options.go
+++ b/step_exec_options.go
@@ -18,7 +18,7 @@ type StepErrorPolicy struct{}
 
 type RetryPolicy interface {
 	// ShouldRetry returns true if the error should be retried, and the duration to wait before retrying.
-	// The int parameter is the retry count
+	// The int parameter is the retry count, first execution fail will invoke this with 0.
 	ShouldRetry(error, uint) (bool, time.Duration)
 }
 

--- a/step_exec_options.go
+++ b/step_exec_options.go
@@ -17,17 +17,21 @@ type StepExecutionOptions struct {
 type StepErrorPolicy struct{}
 
 type RetryPolicy interface {
-	ShouldRetry(error) (bool, time.Duration)
+	// ShouldRetry returns true if the error should be retried, and the duration to wait before retrying.
+	// The int parameter is the retry count
+	ShouldRetry(error, uint) (bool, time.Duration)
 }
 
 // StepContextPolicy allows context enrichment before passing to step.
-//   With StepInstanceMeta you can access StepInstance, StepDefinition, JobInstance, JobDefinition.
+//
+//	With StepInstanceMeta you can access StepInstance, StepDefinition, JobInstance, JobDefinition.
 type StepContextPolicy func(context.Context, StepInstanceMeta) context.Context
 
 type ExecutionOptionPreparer func(*StepExecutionOptions) *StepExecutionOptions
 
 // Add precedence to a step.
-//   without taking input from it(use StepAfter/StepAfterBoth otherwise)
+//
+//	without taking input from it(use StepAfter/StepAfterBoth otherwise)
 func ExecuteAfter(step StepDefinitionMeta) ExecutionOptionPreparer {
 	return func(options *StepExecutionOptions) *StepExecutionOptions {
 		options.DependOn = append(options.DependOn, step.GetName())

--- a/test_joblib_test.go
+++ b/test_joblib_test.go
@@ -321,7 +321,6 @@ func newLinearRetryPolicy(sleepInterval time.Duration, maxRetryCount uint) async
 
 func (lrp *linearRetryPolicy) ShouldRetry(_ error, tried uint) (bool, time.Duration) {
 	if tried < lrp.maxRetryCount {
-		tried++
 		return true, lrp.sleepInterval
 	}
 


### PR DESCRIPTION
retry count is already measured on library level, expose to RetryInterface `ShouldRetry(error, uint) (bool, time.Duration)`, so custom retryPolicy don't need to track it.